### PR TITLE
Merge back AMI IDs from AWS hosted quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The next screen will allow you to fill in the details for the selected launch op
 | Parameter label (name)     | Default   | Description                                                        |
 |----------------------------|-----------|--------------------------------------------------------------------|
 | Stack name                 | Solace-HA | Any globally unique name                                           |
-| **Solace Parameters**      |           |                                                                    |
+| **Solace Configuration**      |           |                                                                    |
 | Solace Docker URL (SolaceDockerURL) | _Requires_ _input_ | Solace PubSub+ software message broker Docker image download URL from Step 1. Can also use load versions hosted remotely (if so, a .md5 file needs to be created in the same remote directory) |
 | Password to access Solace admin console and SEMP (AdminPassword) | _Requires_ _input_ | Password to allow Solace admin access to configure the message broker instances |
 | Container logging format (ContainerLoggingFormat) | graylog | The format of the logs sent by the message broker to the CloudWatch service (see [documentation](https://docs.solace.com/Configuring-and-Managing/SW-Broker-Specific-Config/Docker-Tasks/Configuring-VMR-Container-Logging.htm?Highlight=logging#Config-Out-Form ) for details) |

--- a/templates/nodecreate.template
+++ b/templates/nodecreate.template
@@ -99,55 +99,52 @@
     "Mappings": {
         "AWSAMIRegionMap": {
             "AMI": {
-                "AMZNLINUXHVM": "amzn-ami-hvm-2017.09.1.20180117-x86_64"
+                "AMZNLINUXHVM": "amzn-ami-hvm-2018.03.0.20180508-x86_64-gp2"
             },
             "ap-northeast-1": {
-                "AMZNLINUXHVM": "ami-ceafcba8"
+                "AMZNLINUXHVM": "ami-92df37ed"
             },
             "ap-northeast-2": {
-                "AMZNLINUXHVM": "ami-863090e8"
+                "AMZNLINUXHVM": "ami-c10fa6af"
             },
             "ap-south-1": {
-                "AMZNLINUXHVM": "ami-531a4c3c"
+                "AMZNLINUXHVM": "ami-76d6f519"
             },
             "ap-southeast-1": {
-                "AMZNLINUXHVM": "ami-68097514"
+                "AMZNLINUXHVM": "ami-de90a5a2"
             },
             "ap-southeast-2": {
-                "AMZNLINUXHVM": "ami-942dd1f6"
+                "AMZNLINUXHVM": "ami-423bec20"
             },
             "ca-central-1": {
-                "AMZNLINUXHVM": "ami-a954d1cd"
-            },
-            "cn-north-1": {
-                "AMZNLINUXHVM": "ami-cb19c4a6"
-            },
-            "eu-west-1": {
-                "AMZNLINUXHVM": "ami-d834aba1"
-            },
-            "eu-west-2": {
-                "AMZNLINUXHVM": "ami-403e2524"
-            },
-            "eu-west-3": {
-                "AMZNLINUXHVM": "ami-8ee056f3"
+                "AMZNLINUXHVM": "ami-338a0a57"
             },
             "eu-central-1": {
-                "AMZNLINUXHVM": "ami-5652ce39"
+                "AMZNLINUXHVM": "ami-9a91b371"
+            },
+            "eu-west-1": {
+                "AMZNLINUXHVM": "ami-ca0135b3"
+            },
+            "eu-west-2": {
+                "AMZNLINUXHVM": "ami-a36f8dc4"
+            },
+            "eu-west-3": {
+                "AMZNLINUXHVM": "ami-969c2deb"
             },
             "sa-east-1": {
-                "AMZNLINUXHVM": "ami-84175ae8"
+                "AMZNLINUXHVM": "ami-3885d854"
             },
             "us-east-1": {
-                "AMZNLINUXHVM": "ami-97785bed"
+                "AMZNLINUXHVM": "ami-14c5486b"
             },
             "us-east-2": {
-                "AMZNLINUXHVM": "ami-f63b1193"
+                "AMZNLINUXHVM": "ami-922914f7"
             },
             "us-west-1": {
-                "AMZNLINUXHVM": "ami-824c4ee2"
+                "AMZNLINUXHVM": "ami-25110f45"
             },
             "us-west-2": {
-                "AMZNLINUXHVM": "ami-f2d3638a"
+                "AMZNLINUXHVM": "ami-e251209a"
             }
         },
         "LinuxAMINameMap": {
@@ -167,13 +164,13 @@
         },
         "IOPsMap": {
             "0": {
-                "IOPs" : "0"
+                "IOPs": "0"
             },
             "20": {
-                "IOPs" : "1000"
+                "IOPs": "1000"
             },
             "40": {
-                "IOPs" : "2000"
+                "IOPs": "2000"
             },
             "80": {
                 "IOPs": "4000"
@@ -208,7 +205,6 @@
         }
     },
     "Resources": {
-
         "CloudFormationLogs": {
             "Type": "AWS::Logs::LogGroup",
             "Properties": {
@@ -219,166 +215,238 @@
             "Type": "AWS::CloudWatch::Alarm",
             "Properties": {
                 "AlarmDescription": "Trigger a recovery when instance status check fails for 3 consecutive minutes.",
-                "Namespace": "AWS/EC2" ,
+                "Namespace": "AWS/EC2",
                 "MetricName": "StatusCheckFailed_System",
                 "Statistic": "Minimum",
                 "Period": "60",
                 "EvaluationPeriods": "3",
                 "ComparisonOperator": "GreaterThanThreshold",
                 "Threshold": "0",
-                "AlarmActions": [ {"Fn::Join" : ["", ["arn:aws:automate:", { "Ref" : "AWS::Region" }, ":ec2:recover" ]]} ],
-                "Dimensions": [{"Name": "InstanceId","Value": {"Ref": "NodeLaunchConfig"}}]
+                "AlarmActions": [
+                    {
+                        "Fn::Join": [
+                            "",
+                            [
+                                "arn:aws:automate:",
+                                {
+                                    "Ref": "AWS::Region"
+                                },
+                                ":ec2:recover"
+                            ]
+                        ]
+                    }
+                ],
+                "Dimensions": [
+                    {
+                        "Name": "InstanceId",
+                        "Value": {
+                            "Ref": "NodeLaunchConfig"
+                        }
+                    }
+                ]
             }
         },
         "NodeLaunchConfig": {
             "Type": "AWS::EC2::Instance",
             "Metadata": {
                 "AWS::CloudFormation::Init": {
-                    "configSets" : {
-                        "install_all" : [ "install_awscli", "install_logs", "install_docker", "install_extras", "install_solace" ]
+                    "configSets": {
+                        "install_all": [
+                            "install_awscli",
+                            "install_logs",
+                            "install_docker",
+                            "install_extras",
+                            "install_solace"
+                        ]
                     },
-
-                "install_awscli": {
-                    "packages" : {
-                        "python" : {
-                            "awscli" : []
-                        }
-                    }
-                },
-
-                "install_logs": {
-                    "packages" : {
-                        "yum" : {
-                            "awslogs" : []
-                        }
-                    },
-
-                    "files": {
-                    "/etc/awslogs/awslogs.conf": {
-                        "content": { "Fn::Join": [ "", [
-                        "[general]\n",
-                        "state_file= /var/awslogs/state/agent-state\n",
-
-                        "[/var/log/cloud-init.log]\n",
-                        "file = /var/log/cloud-init.log\n",
-                        "log_group_name = ", { "Ref": "CloudFormationLogs" }, "\n",
-                        "log_stream_name = {instance_id}/cloud-init.log\n",
-                        "datetime_format = \n",
-
-                        "[/var/log/cloud-init-output.log]\n",
-                        "file = /var/log/cloud-init-output.log\n",
-                        "log_group_name = ", { "Ref": "CloudFormationLogs" }, "\n",
-                        "log_stream_name = {instance_id}/cloud-init-output.log\n",
-                        "datetime_format = \n",
-
-                        "[/var/log/cfn-init.log]\n",
-                        "file = /var/log/cfn-init.log\n",
-                        "log_group_name = ", { "Ref": "CloudFormationLogs" }, "\n",
-                        "log_stream_name = {instance_id}/cfn-init.log\n",
-                        "datetime_format = \n",
-
-                        "[/var/log/cfn-hup.log]\n",
-                        "file = /var/log/cfn-hup.log\n",
-                        "log_group_name = ", { "Ref": "CloudFormationLogs" }, "\n",
-                        "log_stream_name = {instance_id}/cfn-hup.log\n",
-                        "datetime_format = \n",
-
-                        "[/var/log/cfn-wire.log]\n",
-                        "file = /var/log/cfn-wire.log\n",
-                        "log_group_name = ", { "Ref": "CloudFormationLogs" }, "\n",
-                        "log_stream_name = {instance_id}/cfn-wire.log\n",
-                        "datetime_format = \n",
-
-                        "[/var/log/solace.log]\n",
-                        "file = /var/log/solace.log\n",
-                        "log_group_name = ", { "Ref": "CloudFormationLogs" }, "\n",
-                        "log_stream_name = {instance_id}/solace.log\n",
-                        "datetime_format = \n"
-                        ] ] },
-                        "mode": "000444",
-                        "owner": "root",
-                        "group": "root"
-                    },
-                    "/etc/awslogs/awscli.conf": {
-                        "content": { "Fn::Join": [ "", [
-                        "[plugins]\n",
-                        "cwlogs = cwlogs\n",
-                        "[default]\n",
-                        "region = ", { "Ref" : "AWS::Region" }, "\n"
-                        ] ] },
-                        "mode": "000444",
-                        "owner": "root",
-                        "group": "root"
-                    }
-                    },
-                    "commands" : {
-                    "01_create_state_directory" : {
-                        "command" : "mkdir -p /var/awslogs/state"
-                    }
-                    },
-                    "services" : {
-                    "sysvinit" : {
-                        "awslogs"    : { "enabled" : "true", "ensureRunning" : "true",
-                                        "files" : [ "/etc/awslogs/awslogs.conf" ] }
-                    }
-                    }
-                },
-
-                "install_docker": {
-                    "packages" : {
-                        "yum" : {
-                            "docker" : [],
-                            "wget" : [],
-                            "lvm2" : []
-                        }
-                    },
-                    "files": {
-                        "/etc/sysconfig/docker": {
-                            "content": { "Fn::Join": [ "", [
-                                "DAEMON_PIDFILE_TIMEOUT=10\n",
-                                "OPTIONS=\"--default-ulimit nofile=1024:4096 --iptables=false --storage-driver overlay2\"\n"
-                            ] ] },
-                            "mode": "000444",
-                            "owner": "root",
-                            "group": "root"
-                        }
-                    },
-                    "commands" : {
-                        "01_add_ec2-user_to_docker_group" : {
-                            "command" : "usermod -a -G docker ec2-user"
-                        }
-                    },
-                    "services" : {
-                        "sysvinit" : {
-                            "docker" : {
-                                "enabled" : "true",
-                                "ensureRunning" : "true",
-                                "files" :[ "/etc/sysconfig/docker" ]
+                    "install_awscli": {
+                        "packages": {
+                            "python": {
+                                "awscli": []
                             }
                         }
-                    }
-                },
-
-                "install_extras": {
-                    "packages" : {
-                        "yum" : {
-                            "epel-release" : [],
-                            "jq" : []
+                    },
+                    "install_logs": {
+                        "packages": {
+                            "yum": {
+                                "awslogs": []
+                            }
+                        },
+                        "files": {
+                            "/etc/awslogs/awslogs.conf": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "[general]\n",
+                                            "state_file= /var/awslogs/state/agent-state\n",
+                                            "[/var/log/cloud-init.log]\n",
+                                            "file = /var/log/cloud-init.log\n",
+                                            "log_group_name = ",
+                                            {
+                                                "Ref": "CloudFormationLogs"
+                                            },
+                                            "\n",
+                                            "log_stream_name = {instance_id}/cloud-init.log\n",
+                                            "datetime_format = \n",
+                                            "[/var/log/cloud-init-output.log]\n",
+                                            "file = /var/log/cloud-init-output.log\n",
+                                            "log_group_name = ",
+                                            {
+                                                "Ref": "CloudFormationLogs"
+                                            },
+                                            "\n",
+                                            "log_stream_name = {instance_id}/cloud-init-output.log\n",
+                                            "datetime_format = \n",
+                                            "[/var/log/cfn-init.log]\n",
+                                            "file = /var/log/cfn-init.log\n",
+                                            "log_group_name = ",
+                                            {
+                                                "Ref": "CloudFormationLogs"
+                                            },
+                                            "\n",
+                                            "log_stream_name = {instance_id}/cfn-init.log\n",
+                                            "datetime_format = \n",
+                                            "[/var/log/cfn-hup.log]\n",
+                                            "file = /var/log/cfn-hup.log\n",
+                                            "log_group_name = ",
+                                            {
+                                                "Ref": "CloudFormationLogs"
+                                            },
+                                            "\n",
+                                            "log_stream_name = {instance_id}/cfn-hup.log\n",
+                                            "datetime_format = \n",
+                                            "[/var/log/cfn-wire.log]\n",
+                                            "file = /var/log/cfn-wire.log\n",
+                                            "log_group_name = ",
+                                            {
+                                                "Ref": "CloudFormationLogs"
+                                            },
+                                            "\n",
+                                            "log_stream_name = {instance_id}/cfn-wire.log\n",
+                                            "datetime_format = \n",
+                                            "[/var/log/solace.log]\n",
+                                            "file = /var/log/solace.log\n",
+                                            "log_group_name = ",
+                                            {
+                                                "Ref": "CloudFormationLogs"
+                                            },
+                                            "\n",
+                                            "log_stream_name = {instance_id}/solace.log\n",
+                                            "datetime_format = \n"
+                                        ]
+                                    ]
+                                },
+                                "mode": "000444",
+                                "owner": "root",
+                                "group": "root"
+                            },
+                            "/etc/awslogs/awscli.conf": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "[plugins]\n",
+                                            "cwlogs = cwlogs\n",
+                                            "[default]\n",
+                                            "region = ",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                "mode": "000444",
+                                "owner": "root",
+                                "group": "root"
+                            }
+                        },
+                        "commands": {
+                            "01_create_state_directory": {
+                                "command": "mkdir -p /var/awslogs/state"
+                            }
+                        },
+                        "services": {
+                            "sysvinit": {
+                                "awslogs": {
+                                    "enabled": "true",
+                                    "ensureRunning": "true",
+                                    "files": [
+                                        "/etc/awslogs/awslogs.conf"
+                                    ]
+                                }
+                            }
                         }
-                    }
-                },
-
-                "install_solace" : {
-                        "commands" : {
-                        "01_create_secrets_directory" : {
-                            "command" : "mkdir -p /mnt/vmr/secrets"
+                    },
+                    "install_docker": {
+                        "packages": {
+                            "yum": {
+                                "docker": [],
+                                "wget": [],
+                                "lvm2": []
+                            }
+                        },
+                        "files": {
+                            "/etc/sysconfig/docker": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "DAEMON_PIDFILE_TIMEOUT=10\n",
+                                            "OPTIONS=\"--default-ulimit nofile=1024:4096 --iptables=false --storage-driver overlay2\"\n"
+                                        ]
+                                    ]
+                                },
+                                "mode": "000444",
+                                "owner": "root",
+                                "group": "root"
+                            }
+                        },
+                        "commands": {
+                            "01_add_ec2-user_to_docker_group": {
+                                "command": "usermod -a -G docker ec2-user"
+                            }
+                        },
+                        "services": {
+                            "sysvinit": {
+                                "docker": {
+                                    "enabled": "true",
+                                    "ensureRunning": "true",
+                                    "files": [
+                                        "/etc/sysconfig/docker"
+                                    ]
+                                }
+                            }
                         }
+                    },
+                    "install_extras": {
+                        "packages": {
+                            "yum": {
+                                "epel-release": [],
+                                "jq": []
+                            }
+                        }
+                    },
+                    "install_solace": {
+                        "commands": {
+                            "01_create_secrets_directory": {
+                                "command": "mkdir -p /mnt/vmr/secrets"
+                            }
                         },
                         "files": {
                             "/mnt/vmr/secrets/solOSpasswd": {
-                                "content": { "Fn::Join": [ "", [
-                                     { "Ref" : "AdminPassword" }, "\n"
-                                ] ] },
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            {
+                                                "Ref": "AdminPassword"
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                }
                             },
                             "/tmp/gen-cluster-hosts.sh": {
                                 "source": {
@@ -392,7 +460,7 @@
                                                     "s3"
                                                 ]
                                             }
-                                         }
+                                        }
                                     ]
                                 },
                                 "mode": "000755",
@@ -411,7 +479,7 @@
                                                     "s3"
                                                 ]
                                             }
-                                         }
+                                        }
                                     ]
                                 },
                                 "mode": "000755",
@@ -420,7 +488,7 @@
                             },
                             "/tmp/wait-for-resource.sh": {
                                 "source": {
-                                     "Fn::Sub": [
+                                    "Fn::Sub": [
                                         "https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/wait-for-resource.sh",
                                         {
                                             "QSS3Region": {
@@ -430,7 +498,7 @@
                                                     "s3"
                                                 ]
                                             }
-                                         }
+                                        }
                                     ]
                                 },
                                 "mode": "000755",
@@ -449,7 +517,7 @@
                                                     "s3"
                                                 ]
                                             }
-                                         }
+                                        }
                                     ]
                                 },
                                 "mode": "000755",
@@ -468,8 +536,8 @@
                                                     "s3"
                                                 ]
                                             }
-                                         }
-                                    ]                         
+                                        }
+                                    ]
                                 },
                                 "mode": "000755",
                                 "owner": "root",
@@ -487,8 +555,8 @@
                                                     "s3"
                                                 ]
                                             }
-                                         }
-                                    ]                         
+                                        }
+                                    ]
                                 },
                                 "mode": "000755",
                                 "owner": "root",
@@ -536,7 +604,7 @@
                                 }
                             },
                             {
-                                 "DeviceName": {
+                                "DeviceName": {
                                     "Fn::FindInMap": [
                                         "Linux2SpoolDisk",
                                         "Amazon-Linux-HVM",
@@ -549,14 +617,16 @@
                                     },
                                     "DeleteOnTermination": "False",
                                     "VolumeType": "io1",
-                                    "Iops":{
+                                    "Iops": {
                                         "Fn::FindInMap": [
                                             "IOPsMap",
-                                            { "Ref": "PersistentStorage" },
+                                            {
+                                                "Ref": "PersistentStorage"
+                                            },
                                             "IOPs"
                                         ]
                                     }
-                                }                               
+                                }
                             }
                         ]
                     ]
@@ -564,7 +634,9 @@
                 "ImageId": {
                     "Fn::FindInMap": [
                         "AWSAMIRegionMap",
-                        { "Ref": "AWS::Region" },
+                        {
+                            "Ref": "AWS::Region"
+                        },
                         "AMZNLINUXHVM"
                     ]
                 },
@@ -574,14 +646,18 @@
                 "KeyName": {
                     "Ref": "KeyPairName"
                 },
-                "NetworkInterfaces" : [
+                "NetworkInterfaces": [
                     {
-                        "AssociatePublicIpAddress" : true,
-                        "DeleteOnTermination" : true,
-                        "Description"         : "Main interface",
-                        "DeviceIndex"         : "0",
-                        "GroupSet"            : { "Ref": "NodeSecurityGroup" },
-                        "SubnetId"            : { "Ref" : "SubnetID" }
+                        "AssociatePublicIpAddress": true,
+                        "DeleteOnTermination": true,
+                        "Description": "Main interface",
+                        "DeviceIndex": "0",
+                        "GroupSet": {
+                            "Ref": "NodeSecurityGroup"
+                        },
+                        "SubnetId": {
+                            "Ref": "SubnetID"
+                        }
                     }
                 ],
                 "IamInstanceProfile": {
@@ -628,56 +704,91 @@
                                 "\n",
                                 "## Retrieve scripts to deploy Solace on the instances \n",
                                 "/opt/aws/bin/cfn-init -v ",
-                                "    --stack ", { "Ref": "AWS::StackName" },
+                                "    --stack ",
+                                {
+                                    "Ref": "AWS::StackName"
+                                },
                                 "    --resource NodeLaunchConfig ",
                                 "    --configsets install_all ",
-                                "    --region ", { "Ref": "AWS::Region" },
+                                "    --region ",
+                                {
+                                    "Ref": "AWS::Region"
+                                },
                                 "\n",
                                 "## Wait for all nodes to come on-line\n",
                                 "$AMI_SBIN/wait-for-child-resource.sh ",
-                                { "Ref": "ParentStackName" },
+                                {
+                                    "Ref": "ParentStackName"
+                                },
                                 " MonitorStack NodeLaunchConfig\n",
                                 "\n",
                                 "$AMI_SBIN/wait-for-child-resource.sh ",
-                                { "Ref": "ParentStackName" },
+                                {
+                                    "Ref": "ParentStackName"
+                                },
                                 " MessageRouterPrimaryStack NodeLaunchConfig\n",
                                 "\n",
                                 "$AMI_SBIN/wait-for-child-resource.sh ",
-                                {  "Ref": "ParentStackName" },
+                                {
+                                    "Ref": "ParentStackName"
+                                },
                                 " MessageRouterBackupStack NodeLaunchConfig\n",
                                 "\n",
                                 "## Now find the private IP addresses of all deployed nodes\n",
                                 "##   (generating /tmp/solacehosts and /tmp/<role> files)\n",
                                 "$AMI_SBIN/gen-cluster-hosts.sh ",
-                                { "Ref": "ParentStackName" },
+                                {
+                                    "Ref": "ParentStackName"
+                                },
                                 "\n",
                                 "## Tag the instance (now that we're sure of launch index)\n",
                                 "instance_id=$(curl -f http://instance-data/latest/meta-data/instance-id)\n",
-                                "instance_tag=",{ "Ref": "ParentStackName" },"-",{ "Ref": "NodeDesignation" },"\n",
+                                "instance_tag=",
+                                {
+                                    "Ref": "ParentStackName"
+                                },
+                                "-",
+                                {
+                                    "Ref": "NodeDesignation"
+                                },
+                                "\n",
                                 " \n",
                                 "aws ec2 create-tags",
-                                "    --region ",{ "Ref": "AWS::Region" },
+                                "    --region ",
+                                {
+                                    "Ref": "AWS::Region"
+                                },
                                 "    --resources $instance_id --tags Key=Name,Value=$instance_tag\n",
                                 "\n",
                                 "cd /tmp\n",
                                 "# Install Solace\n",
                                 "$AMI_SBIN/install-solace.sh -c /tmp/solacehosts -d /tmp/solace",
                                 "  -u ",
-                                    { "Ref": "SolaceDockerURL" },
+                                {
+                                    "Ref": "SolaceDockerURL"
+                                },
                                 "  -p /mnt/vmr/secrets/solOSpasswd",
                                 "  -s ",
-                                   { "Ref": "PersistentStorage" },
+                                {
+                                    "Ref": "PersistentStorage"
+                                },
                                 "  -v /dev/xvdb",
                                 "  -f ",
-                                    { "Ref": "ContainerLoggingFormat" },
+                                {
+                                    "Ref": "ContainerLoggingFormat"
+                                },
                                 "  -g ",
-                                    { "Ref": "CloudFormationLogs" },
+                                {
+                                    "Ref": "CloudFormationLogs"
+                                },
                                 "  -r ${instance_id}/solace.log",
                                 " \n",
                                 "## Signal back information for outputs (now that all nodes are up) \n",
                                 "/opt/aws/bin/cfn-signal -e 0 -r 'Solace HA deployment complete' '",
-                                   { "Ref": "ClusterInfoHandle" },
-                                   "'\n",
+                                {
+                                    "Ref": "ClusterInfoHandle"
+                                },
+                                "'\n",
                                 "\n"
                             ]
                         ]
@@ -689,7 +800,9 @@
     "Outputs": {
         "EC2ID": {
             "Description": "Reference to created ec2 instance",
-            "Value": { "Ref": "NodeLaunchConfig" },
+            "Value": {
+                "Ref": "NodeLaunchConfig"
+            },
             "Export": {
                 "Name": {
                     "Fn::Sub": "${AWS::StackName}-EC2ID"

--- a/templates/solace-master.template
+++ b/templates/solace-master.template
@@ -6,7 +6,7 @@
             "ParameterGroups": [
                 {
                     "Label": {
-                        "default": "Solace Parameters"
+                        "default": "Solace Configuration"
                     },
                     "Parameters": [
                         "SolaceDockerURL",

--- a/templates/solace.template
+++ b/templates/solace.template
@@ -5,7 +5,7 @@
         "AWS::CloudFormation::Interface": {
             "ParameterGroups": [
                 {
-                    "Label": { "default": "Solace Parameters" },
+                    "Label": { "default": "Solace Configuration" },
                     "Parameters": [
                         "SolaceDockerURL",
                         "AdminPassword",
@@ -898,7 +898,7 @@
                     "Timeout" : "3",
                     "Interval" : "5",
                     "UnhealthyThreshold" : "2",
-                    "HealthyThreshold" : "2",
+                    "HealthyThreshold" : "2"
                 },
                 "Listeners" : [
                     {


### PR DESCRIPTION
AWS have updated their AMI IDs and this PR is to bring it to SolaceProducts. Also adding minor changes to bring the two repos as close as possible (the diff is only the S3 bucket names used)